### PR TITLE
feat: add `DELETE` support for `/resume/education`

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,6 +66,28 @@ def education():
     return jsonify({})
 
 
+@app.route('/resume/education/<int:index>', methods=['DELETE'])
+def delete_education(index):
+    """
+    Deletes an education entry at the specified index.
+
+    Parameters
+    ----------
+    index : int
+        The index of the education entry to delete.
+
+    Returns
+    -------
+    Response
+        JSON response indicating success (with `deleted: True`) or
+        failure (with an error message and 404 status code).
+    """
+    if 0 <= index < len( data[ "education" ] ):
+        data[ "education" ].pop( index )
+        return jsonify( { "deleted": True } ), 200
+    return jsonify( { "error": "Index out of range" } ), 404
+
+
 @app.route('/resume/skill', methods=['GET', 'POST'])
 def skill():
     '''

--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ def delete_education(index):
     """
     if 0 <= index < len( data[ "education" ] ):
         data[ "education" ].pop( index )
-        return jsonify( { "deleted": True } ), 200
+        return jsonify( { "message": "Education has been deleted" } ), 200
     return jsonify( { "error": "Index out of range" } ), 404
 
 

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -73,6 +73,7 @@ def test_delete_education():
     client = app.test_client()
 
     # Add new education:
+    # TODO: Implement the '/resume/education' POST route in `app.py` before running this test.
     post_resp = client.post('/resume/education', json=example_education)
     assert post_resp.status_code == 200
     item_id = post_resp.json['id']

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -81,7 +81,7 @@ def test_delete_education():
     # Delete the education using the ID:
     del_resp = client.delete(f'/resume/education/{item_id}')
     assert del_resp.status_code == 200
-    assert del_resp.json['deleted'] is True
+    assert del_resp.json['message'] == "Education has been deleted"
 
     # Delete again to check if it fails:
     del_resp = client.delete(f'/resume/education/{item_id}')

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -73,7 +73,7 @@ def test_delete_education():
     client = app.test_client()
 
     # Add new education:
-    # TODO: Implement the '/resume/education' POST route in `app.py` before running this test.
+    # TODO: Implement the '/resume/education' POST route in `app.py` before running this test. # pylint: disable=fixme
     post_resp = client.post('/resume/education', json=example_education)
     assert post_resp.status_code == 200
     item_id = post_resp.json['id']

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -55,6 +55,39 @@ def test_education():
     assert response.json[item_id] == example_education
 
 
+def test_delete_education():
+    '''
+    Add and delete an education entry by index.
+
+    Check that the entry is deleted successfully and the response is correct.
+    '''
+    example_education = {
+        "course": "Computer Science",
+        "school": "UBC",
+        "start_date": "January 2022",
+        "end_date": "June 2026",
+        "grade": "90%",
+        "logo": "example-logo.png"
+    }
+
+    client = app.test_client()
+
+    # Add new education:
+    post_resp = client.post('/resume/education', json=example_education)
+    assert post_resp.status_code == 200
+    item_id = post_resp.json['id']
+
+    # Delete the education using the ID:
+    del_resp = client.delete(f'/resume/education/{item_id}')
+    assert del_resp.status_code == 200
+    assert del_resp.json['deleted'] is True
+
+    # Delete again to check if it fails:
+    del_resp = client.delete(f'/resume/education/{item_id}')
+    assert del_resp.status_code == 404
+    assert del_resp.json['error'] == "Index out of range"
+
+
 def test_skill():
     '''
     Add a new skill and then get all skills. 


### PR DESCRIPTION
Resolves https://github.com/MLH-Fellowship/orientation-project-python-25.SUM.a/issues/4

This PR:

- Adds support for deleting an education entry by its index via a `DELETE` request to `/resume/education/<int:index>`.
- Includes a corresponding test to verify successful deletion.