### PR TITLE
feat: add `POST` support for `/resume/education`

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def education():
         - All education entries with status 200 (on GET).
         - The index of the newly added entry with status 201 (on valid POST).
         - An error message with status 400 if POST data is missing or invalid.
-        - An empty JSON object for unsupported methods (though all are handled).
+        - An error message with status 405 if the HTTP method is not allowed.
     """
     if request.method == 'GET':
         return jsonify({})

--- a/app.py
+++ b/app.py
@@ -86,12 +86,19 @@ def get_experience_by_index(index):
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
     """
-    Handle GET and POST requests for education entries.
+    Handles GET and POST requests for education entries.
+
+    GET: Returns all stored education entries.
+    POST: Adds a new education entry to the system after validating required fields.
 
     Returns
     -------
     Response
-        JSON response containing all education entries (GET) or the index of a new entry (POST).
+        JSON response containing:
+        - All education entries with status 200 (on GET).
+        - The index of the newly added entry with status 201 (on valid POST).
+        - An error message with status 400 if POST data is missing or invalid.
+        - An empty JSON object for unsupported methods (though all are handled).
     """
     if request.method == 'GET':
         return jsonify({})

--- a/app.py
+++ b/app.py
@@ -108,7 +108,7 @@ def education():
 
         # Check if the content is empty:
         if not content:
-            return jsonify({"error": "No data provided"}), 400
+            return jsonify({"error": "Bad request"}), 400
 
         # Check if all required fields are present:
         required_fields = [

--- a/app.py
+++ b/app.py
@@ -54,14 +54,33 @@ def experience():
 
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
-    '''
-    Handles education requests
-    '''
+    """
+    Handle GET and POST requests for education entries.
+
+    Returns
+    -------
+    Response
+        JSON response containing all education entries (GET) or the index of a new entry (POST).
+    """
     if request.method == 'GET':
         return jsonify({})
 
     if request.method == 'POST':
-        return jsonify({})
+        content = request.json
+        if not content:
+            return jsonify({"error": "No data provided"}), 400
+        if not all(key in content for key in ['course', 'school', 'start_date', 'end_date', 'grade', 'logo']):
+            return jsonify({"error": "Missing required fields"}), 400
+        new_education = Education(
+            content['course'],
+            content['school'],
+            content['start_date'],
+            content['end_date'],
+            content['grade'],
+            content['logo']
+        )
+        data['education'].append(new_education)
+        return jsonify({"id": len(data['education']) - 1}), 201
 
     return jsonify({})
 

--- a/app.py
+++ b/app.py
@@ -67,10 +67,19 @@ def education():
 
     if request.method == 'POST':
         content = request.json
+
+        # Check if the content is empty:
         if not content:
             return jsonify({"error": "No data provided"}), 400
-        if not all(key in content for key in ['course', 'school', 'start_date', 'end_date', 'grade', 'logo']):
+
+        # Check if all required fields are present:
+        required_fields = [
+            'course', 'school', 'start_date', 'end_date', 'grade', 'logo'
+        ]
+        if not all( key in content for key in required_fields):
             return jsonify({"error": "Missing required fields"}), 400
+
+        # Create a new Education object, add it to the data, and return the index:
         new_education = Education(
             content['course'],
             content['school'],

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -36,10 +36,21 @@ def test_experience():
 
 def test_education():
     '''
-    Add a new education and then get all educations. 
-    
-    Check that it returns the new education in that list
+    Test the /resume/education POST and GET endpoints.
+
+    - Ensure an empty payload returns a 400 error.
+    - Ensure missing required fields return a 400 error.
+    - Successfully add a valid education entry.
+    - Confirm the entry is correctly returned via GET.
     '''
+    empty_education = {}
+    missing_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    }
     example_education = {
         "course": "Engineering",
         "school": "NYU",
@@ -48,12 +59,31 @@ def test_education():
         "grade": "86%",
         "logo": "example-logo.png"
     }
-    item_id = app.test_client().post('/resume/education',
-                                     json=example_education).json['id']
 
-    response = app.test_client().get('/resume/education')
+    client = app.test_client()
+
+    # Test empty payload:
+    response = client.post('/resume/education', json=empty_education)
+    assert response.status_code == 400
+    assert response.json['error'] == "No data provided"
+
+    # Test missing field:
+    response = client.post('/resume/education', json=missing_education)
+    assert response.status_code == 400
+    assert response.json['error'] == "Missing required fields"
+
+    # Test valid education:
+    response = client.post('/resume/education', json=example_education)
+    assert response.status_code == 201
+    item_id = response.json['id']
+    assert isinstance(item_id, int)
+    assert item_id == 1
+
+    # Test retrieval:
+    # TODO: The GET endpoint needs to be implemented in `app.py` for this to pass. # pylint: disable=fixme
+    response = client.get('/resume/education')
+    assert response.status_code == 200
     assert response.json[item_id] == example_education
-
 
 def test_skill():
     '''


### PR DESCRIPTION
Resolves https://github.com/MLH-Fellowship/orientation-project-python-25.SUM.a/issues/19

This PR:

- Implements support for adding a new education entry via a `POST` request to `/resume/education`.
- Validates input payloads and returns appropriate error messages for missing or empty data.
- Adds corresponding tests to verify success and failure cases for the POST route.