### PR TITLE
Added PUT /resume/experience/<item_id> to update Experience and corresponding test

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 '''
 Flask Application
 '''
+from dataclasses import fields
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
 from utils import validate_data
@@ -107,6 +108,34 @@ def get_experience_by_index(index):
     except IndexError:
         return jsonify({"error": "Experience not found"}), 404
 
+@app.route('/resume/experience/<int:item_id>', methods=['PUT'])
+def update_experience(item_id):
+    """
+    Update an experience by index.
+
+    Parameters
+    ----------
+    index : int
+        The index of the experience to update.
+
+    Returns
+    -------
+    Response
+        JSON message indicating success or error.
+        Returns 404 if experience not found
+        Returns 400 if request is invalid. 
+    """
+    content = request.json
+    if not content:
+        return jsonify({"error": "Invalid request"}), 400
+
+    if 0 <= item_id < len(data['experience']):
+        valid_keys = {f.name for f in fields(Experience)}
+        filtered_content = {k: v for k, v in content.items() if k in valid_keys}
+
+        data['experience'][item_id] = Experience(**filtered_content)
+        return jsonify({"message": "Experience updated successfully"})
+    return jsonify({"error": "Experience not found"}), 404
 
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():

--- a/app.py
+++ b/app.py
@@ -134,7 +134,7 @@ def update_experience(item_id):
         filtered_content = {k: v for k, v in content.items() if k in valid_keys}
 
         data['experience'][item_id] = Experience(**filtered_content)
-        return jsonify({"message": "Experience updated successfully"})
+        return jsonify({"message": "Experience updated successfully"}), 200
     return jsonify({"error": "Experience not found"}), 404
 
 @app.route('/resume/education', methods=['GET', 'POST'])

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -98,6 +98,84 @@ def test_get_experience_by_id():
     assert response.status_code == 404
     assert response.json['error'] == "Experience not found"
 
+def test_update_experience():
+    """
+    Update an experience and check that it correctly updates.
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    updated_data = {**example_experience, "title": "Senior Software Dev"}
+    response = app.test_client().put(f'/resume/experience/{item_id}', json=updated_data)
+
+    assert response.status_code == 200
+    response_data = response.json
+    assert response_data['message'] == "Experience updated successfully"
+    get_response = app.test_client().get('/resume/experience')
+    updated_experience = get_response.json[item_id]
+
+    assert updated_experience["title"] == updated_data['title']
+    assert updated_experience["company"] == updated_data['company']
+    assert updated_experience["start_date"] == updated_data['start_date']
+    assert updated_experience["end_date"] == updated_data['end_date']
+    assert updated_experience["description"] == updated_data['description']
+    assert updated_experience["logo"] == updated_data['logo']
+
+def test_update_experience_with_unknown_field():
+    """
+    Update an experience with a field not part of the Experience model.
+    This should still return 200, but the unknown field should not be saved.
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    updated_experience = {
+        **example_experience,
+        "title": "Updated Title",
+        "new_field": "This should not be saved"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    response = app.test_client().put(f'/resume/experience/{item_id}', json=updated_experience)
+    assert response.status_code == 200
+    get_response = app.test_client().get('/resume/experience')
+    saved_data = get_response.json[item_id]
+    assert "new_field" not in saved_data
+    assert saved_data["title"] == "Updated Title"
+
+def test_update_experience_invalid_id():
+    """
+    Update an experience with an invalid id and check that it returns a 404
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    updated_experience = {**example_experience, 'company': 'New Company'}
+    response = app.test_client().put(f'/resume/experience/{item_id + 1}', json=updated_experience)
+    assert response.status_code == 404
+    response_data = response.json
+    assert response_data['error'] == "Experience not found"
+
 def test_education():
     '''
     Add a new education and then get all educations.


### PR DESCRIPTION
### Summary
- Added `PUT /resume/experience/<item_id>` route to update an existing experience by index.
- Included error handling for invalid index.
- Added a test in `test_pytest.py` to verify the update behavior.

### Test Coverage
✅ Valid update request  
✅ Invalid index   
✅ Extra fields ignored

Closes  #8 
