### PR TITLE
Added PUT /resume/education/<item_id> to update Experience and corresponding test

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 '''
 Flask Application
 '''
+from dataclasses import fields
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
 from utils import validate_data
@@ -107,6 +108,38 @@ def get_experience_by_index(index):
     except IndexError:
         return jsonify({"error": "Experience not found"}), 404
 
+@app.route('/resume/experience/<int:item_id>', methods=['PUT'])
+def update_experience(item_id):
+    """
+    Update an experience by index.
+
+    Parameters
+    ----------
+    item_id : int
+        The index of the experience to update.
+
+    Returns
+    -------
+    Response
+        JSON message indicating success or error.
+        Returns 404 if experience not found.
+        Returns 400 if request is invalid. 
+    """
+    content = request.json
+    if not content:
+        return jsonify({"error": "Invalid request"}), 400
+
+    if 0 <= item_id < len(data['experience']):
+        try:
+            valid_keys = {f.name for f in fields(Experience)}
+            filtered_content = {k: v for k, v in content.items() if k in valid_keys}
+            data['experience'][item_id] = Experience(**filtered_content)
+            return jsonify({"message": "Experience updated successfully"}), 200
+        except TypeError as e:
+            return jsonify({"error": f"Missing or invalid fields: {str(e)}"}), 400
+
+    return jsonify({"error": "Experience not found"}), 404
+
 
 @app.route('/resume/education', methods=['GET', 'POST'])
 def education():
@@ -152,6 +185,38 @@ def education_by_index(index):
             return jsonify({"message": "Education has been deleted"}), 200
         return jsonify({"error": "400 Bad Request"}), 400
     return jsonify({"error": "Method not allowed"}), 405
+
+@app.route('/resume/education/<int:item_id>', methods=['PUT'])
+def update_education(item_id):
+    """
+    Update an education by index.
+
+    Parameters
+    ----------
+    item_id : int
+        The index of the education to update.
+
+    Returns
+    -------
+    Response
+        JSON message indicating success or error.
+        Returns 404 if education not found.
+        Returns 400 if request is invalid. 
+    """
+    content = request.json
+    if not content:
+        return jsonify({"error": "Invalid request"}), 400
+
+    if 0 <= item_id < len(data['education']):
+        try:
+            valid_keys = {f.name for f in fields(Education)}
+            filtered_content = {k: v for k, v in content.items() if k in valid_keys}
+            data['education'][item_id] = Education(**filtered_content)
+            return jsonify({"message": "Education updated successfully"}), 200
+        except TypeError as e:
+            return jsonify({"error": f"Missing or invalid fields: {str(e)}"}), 400
+
+    return jsonify({"error": "Education not found"}), 404
 
 
 @app.route('/resume/skill', methods=['GET', 'POST'])

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -98,6 +98,112 @@ def test_get_experience_by_id():
     assert response.status_code == 404
     assert response.json['error'] == "Experience not found"
 
+def test_update_experience():
+    """
+    Update an experience and check that it correctly updates.
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    updated_data = {**example_experience, "title": "Senior Software Dev"}
+    response = app.test_client().put(f'/resume/experience/{item_id}', json=updated_data)
+
+    assert response.status_code == 200
+    response_data = response.json
+    assert response_data['message'] == "Experience updated successfully"
+    get_response = app.test_client().get('/resume/experience')
+    updated_experience = get_response.json[item_id]
+
+    assert updated_experience["title"] == updated_data['title']
+    assert updated_experience["company"] == updated_data['company']
+    assert updated_experience["start_date"] == updated_data['start_date']
+    assert updated_experience["end_date"] == updated_data['end_date']
+    assert updated_experience["description"] == updated_data['description']
+    assert updated_experience["logo"] == updated_data['logo']
+
+def test_update_experience_with_unknown_field():
+    """
+    Update an experience with a field not part of the Experience model.
+    This should still return 200, but the unknown field should not be saved.
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    updated_experience = {
+        **example_experience,
+        "title": "Updated Title",
+        "new_field": "This should not be saved"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    response = app.test_client().put(f'/resume/experience/{item_id}', json=updated_experience)
+    assert response.status_code == 200
+    get_response = app.test_client().get('/resume/experience')
+    saved_data = get_response.json[item_id]
+    assert "new_field" not in saved_data
+    assert saved_data["title"] == "Updated Title"
+
+def test_update_experience_invalid_id():
+    """
+    Update an experience with an invalid id and check that it returns a 404
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    updated_experience = {**example_experience, 'company': 'New Company'}
+    response = app.test_client().put(f'/resume/experience/{item_id + 1}', json=updated_experience)
+    assert response.status_code == 404
+    response_data = response.json
+    assert response_data['error'] == "Experience not found"
+
+def test_update_experience_with_missing_fields():
+    """
+    Try updating an experience with missing required fields.
+    Should return 400 Bad Request.
+    """
+    example_experience = {
+        "title": "Software Developer",
+        "company": "G-research",
+        "start_date": "May 2025",
+        "end_date": "Present",
+        "description": "Writing C-sharp Code",
+        "logo": "example-logo.png"
+    }
+
+    invalid_update = {
+        "company": "New Company",
+        "start_date": "June 2025",
+        "end_date": "Present",
+        "description": "Updated Description",
+        "logo": "new-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/experience', json=example_experience).json['id']
+    response = app.test_client().put(f'/resume/experience/{item_id}', json=invalid_update)
+    assert response.status_code == 400
+    assert "error" in response.json
+
+
 def test_education():
     '''
     Add a new education and then get all educations.
@@ -171,6 +277,116 @@ def test_get_education_by_id():
     response = app.test_client().get('/resume/education/999')
     assert response.status_code == 404
     assert response.json['error'] == "Education not found"
+
+def test_update_education():
+    """
+    Update an education and check that it correctly updates.
+    """
+    example_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/education', json=example_education).json['id']
+    updated_data = {**example_education, "course": "Computer Science"}
+    response = app.test_client().put(f'/resume/education/{item_id}', json=updated_data)
+
+    assert response.status_code == 200
+    response_data = response.json
+    assert response_data['message'] == "Education updated successfully"
+
+    get_response = app.test_client().get('/resume/education')
+    updated_education = get_response.json[item_id]
+
+    assert updated_education["course"] == updated_data['course']
+    assert updated_education["school"] == updated_data['school']
+    assert updated_education["start_date"] == updated_data['start_date']
+    assert updated_education["end_date"] == updated_data['end_date']
+    assert updated_education["grade"] == updated_data['grade']
+    assert updated_education["logo"] == updated_data['logo']
+
+
+def test_update_education_with_unknown_field():
+    """
+    Update an education with a field not part of the Education model.
+    This should still return 200, but the unknown field should not be saved.
+    """
+    example_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    }
+
+    updated_education = {
+        **example_education,
+        "course": "Health Sciences",
+        "new_field": "This should not be saved"
+    }
+
+    item_id = app.test_client().post('/resume/education', json=example_education).json['id']
+    response = app.test_client().put(f'/resume/education/{item_id}', json=updated_education)
+
+    assert response.status_code == 200
+    get_response = app.test_client().get('/resume/education')
+    saved_data = get_response.json[item_id]
+    assert "new_field" not in saved_data
+    assert saved_data["course"] == "Health Sciences"
+
+
+def test_update_education_invalid_id():
+    """
+    Update an education with an invalid id and check that it returns a 404
+    """
+    example_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/education', json=example_education).json['id']
+    updated_education = {**example_education, 'course': 'Changed Course'}
+    response = app.test_client().put(f'/resume/education/{item_id + 1}', json=updated_education)
+
+    assert response.status_code == 404
+    response_data = response.json
+    assert response_data['error'] == "Education not found"
+
+def test_update_education_with_missing_fields():
+    """
+    Try updating an education with missing required fields.
+    Should return 400 Bad Request.
+    """
+    example_education = {
+        "course": "Engineering",
+        "school": "NYU",
+        "start_date": "October 2022",
+        "end_date": "August 2024",
+        "grade": "86%",
+        "logo": "example-logo.png"
+    }
+
+    invalid_update = {
+        "course": "Physics",
+        "start_date": "January 2023",
+        "end_date": "May 2024",
+        "grade": "90%",
+        "logo": "new-logo.png"
+    }
+
+    item_id = app.test_client().post('/resume/education', json=example_education).json['id']
+    response = app.test_client().put(f'/resume/education/{item_id}', json=invalid_update)
+    assert response.status_code == 400
+    assert "error" in response.json
 
 
 def test_delete_education():


### PR DESCRIPTION
## Summary

- Added `PUT /resume/education/<item_id>` route to update an existing education entry by index.  
- Updated `PUT /resume/experience/<item_id>` to validate fields before updating.  
- Implemented error handling for invalid/missing request data in both routes.  
- Added corresponding test cases in `test_pytest.py`

## Test Coverage

- ✅ Valid update request
- ✅ Invalid index returns 404  
- ✅ Extra fields in request are ignored  
- ✅ Missing or invalid fields return 400

Closes #7 
